### PR TITLE
IRT-4789

### DIFF
--- a/src/main/java/com/figaf/integration/cpi/client/CpiIntegrationFlowClient.java
+++ b/src/main/java/com/figaf/integration/cpi/client/CpiIntegrationFlowClient.java
@@ -97,6 +97,7 @@ public class CpiIntegrationFlowClient extends CpiRuntimeArtifactClient {
 
     }
 
+    @Deprecated
     public void updateIFlow(RequestContext requestContext, UpdateIFlowRequest request) {
         log.debug("#updateIFlow(RequestContext requestContext, UpdateIFlowRequest request): {}, {}", requestContext, request);
         updateArtifact(requestContext, request);

--- a/src/main/java/com/figaf/integration/cpi/client/CpiMessageMappingClient.java
+++ b/src/main/java/com/figaf/integration/cpi/client/CpiMessageMappingClient.java
@@ -73,6 +73,7 @@ public class CpiMessageMappingClient extends CpiRuntimeArtifactClient {
 
     }
 
+    @Deprecated
     public void updateMessageMapping(RequestContext requestContext, UpdateMessageMappingRequest request) {
         log.debug("#updateMessageMapping(RequestContext requestContext, UpdateMessageMappingRequest request): {}, {}", requestContext, request);
         updateArtifact(requestContext, request);

--- a/src/main/java/com/figaf/integration/cpi/client/CpiRestAndSoapApiClient.java
+++ b/src/main/java/com/figaf/integration/cpi/client/CpiRestAndSoapApiClient.java
@@ -123,6 +123,7 @@ public class CpiRestAndSoapApiClient extends CpiRuntimeArtifactClient {
         );
     }
 
+    @Deprecated
     public void updateRestOrSoapApi(RequestContext requestContext, UpdateRestOrSoapApiRequest request) {
         log.debug("#updateRestOrSoapApi(RequestContext requestContext, UpdateRestOrSoapApiRequest request): {}, {}", requestContext, request);
         updateArtifact(requestContext, request);

--- a/src/main/java/com/figaf/integration/cpi/client/CpiRuntimeArtifactClient.java
+++ b/src/main/java/com/figaf/integration/cpi/client/CpiRuntimeArtifactClient.java
@@ -145,14 +145,15 @@ public class CpiRuntimeArtifactClient extends CpiBaseClient {
         );
     }
 
-    public void updateArtifact(RequestContext requestContext, CreateOrUpdateCpiArtifactRequest request) {
+    public void updateArtifact(RequestContext requestContext, CreateOrUpdateCpiArtifactRequest createOrUpdateCpiArtifactRequest) {
+        log.debug("#updateArtifact: requestContext={}, createOrUpdateCpiArtifactRequest={}", requestContext, createOrUpdateCpiArtifactRequest);
         executeMethod(
             requestContext,
-            String.format(API_UPDATE_ARTIFACT, request.getPackageExternalId()),
+            String.format(API_UPDATE_ARTIFACT, createOrUpdateCpiArtifactRequest.getPackageExternalId()),
             (url, token, restTemplateWrapper) -> {
                 uploadArtifact(
                     requestContext.getConnectionProperties(),
-                    request,
+                    createOrUpdateCpiArtifactRequest,
                     url,
                     token,
                     restTemplateWrapper

--- a/src/main/java/com/figaf/integration/cpi/client/CpiScriptCollectionClient.java
+++ b/src/main/java/com/figaf/integration/cpi/client/CpiScriptCollectionClient.java
@@ -78,6 +78,7 @@ public class CpiScriptCollectionClient extends CpiRuntimeArtifactClient {
 
     }
 
+    @Deprecated
     public void updateScriptCollection(RequestContext requestContext, UpdateScriptCollectionRequest request) {
         log.debug("#updateScriptCollection(RequestContext requestContext, UpdateScriptCollectionRequest request): {}, {}",
             requestContext, request);

--- a/src/main/java/com/figaf/integration/cpi/client/CpiValueMappingClient.java
+++ b/src/main/java/com/figaf/integration/cpi/client/CpiValueMappingClient.java
@@ -73,6 +73,7 @@ public class CpiValueMappingClient extends CpiRuntimeArtifactClient {
 
     }
 
+    @Deprecated
     public void updateValueMapping(RequestContext requestContext, UpdateValueMappingRequest request) {
         log.debug("#updateValueMapping(RequestContext requestContext, UpdateValueMappingRequest request): {}, {}", requestContext, request);
         updateArtifact(requestContext, request);


### PR DESCRIPTION
Refactor the signatures of the update artifact method in cpi-api to utilize the parent update of CpiRuntimeArtifactClient -- deprecate methods